### PR TITLE
ensure default value for private var '_package_install_noop_msg' is set

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@ install_type: gem
 gem_version: "1.7.4"
 
 package_url: ''
+_package_install_noop_msg: ''
 
 _config_dir: "/etc/fluent"
 _config_file: fluent.conf


### PR DESCRIPTION
This change should prevent error messages like the following in which the var is only defined if the detected OS family and distribution is recognized and supported.

```"msg": "The conditional check '_package_install_noop_msg not in script_result.stdout' failed. The error was: error while evaluating conditional (_package_install_noop_msg not in script_result.stdout): Unable to look up a name or access an attribute in template string ({% if _package_install_noop_msg not in script_result.stdout %} True {% else %} False {% endif %}).\nMake sure your variable name does not contain invalid characters like '-': argument of type 'AnsibleUndefined' is not iterable"```